### PR TITLE
Add inventory to cache on creating.

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -522,3 +522,11 @@ RegisterNetEvent('qb-inventory:server:SetInventoryData', function(fromInventory,
         end
     end
 end)
+
+-- Event to add the custom inventory created to Inventory cache.
+RegisterNetEvent('qb-inventory:server:addInventoryToCache', function(invId, inventoryData)
+    Inventories[invId] = {
+        isOpen = false,
+        items = inventoryData
+    }
+end)


### PR DESCRIPTION
## Description
If someone try to create a custom inventory other than stash, glovebox, shop it is currently impossible to add the inventory to existing server inventory cache.
Created a new event to add the new inventory to the `Inventories` cache in server/main.lua file.

Usage in server scripts:
```
    TriggerEvent("qb-inventory:server:addInventoryToCache", inventoryName, InventoryItems)
    exports["qb-inventory"]:OpenInventory(src, inventoryName)
```
By this way we can add a new inventory, for example `Lockers` which is a custom inventory and Open the inventory right after creating it.
Note: Adding the inventory to database will be done within the resource of custom inventory.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new event for adding inventories to the cache, enhancing inventory management capabilities.
  
- **Bug Fixes**
	- Maintained existing logic for player interactions with inventories, ensuring consistent functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->